### PR TITLE
Fixing bugs on cancel() and retrieveExpiredTokens() for put options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,6 @@ Option exercising window start time. When current time is greater or equal to `e
 
 Option exercising window end time. When current time is greater or equal to `exerciseWindowStart` and below or equal to `exerciseWindowEnd`, owner of option(s) can exercise them. When current time is greater than `exerciseWindowEnd`, option holder can't exercise and writer can retrieve remaining underlying (call) or strike (put) tokens.
 
-#### `data`
-
-**Type: `bytes`**
-
-Additional data that can be passed to contract function as a part of option issuance to add flexibility. For standard vanilla options this field is zero-sized array.
-
 ### Function Descriptions
 
 #### `create`
@@ -241,7 +235,7 @@ Returns all the key information for the option issuance with the given `id`.
 event Created(uint256 id);
 ```
 
-Emitted when the writer has provided option issuance data successfully (and locked down the collateral to the contract). The given `id` identifies the particualr option issuance.
+Emitted when the writer has provided option issuance data successfully (and locked down the collateral to the contract). The given `id` identifies the particular option issuance.
 
 #### `Bought`
 
@@ -302,7 +296,6 @@ To create the contract, he will give the following parameters:
 - `premium`: **10000000000000000000** *(10 \* 10^(DAI's decimals))*
 - `exerciseWindowStart`: **1689292800** *(2023-07-14 timestamp)*
 - `exerciseWindowEnd`: **1689465600** *(2023-07-16 timestamp)*
-- `data`: **[]**
 
 Once the contract created, Bob has to transfer the collateral to the contract. This collateral corresponds to the tokens he will have to give Alice if she decides to exercise the option. For this option, he has to give as collateral 8 LINK. He does that by calling the function `approve(address spender, uint256 amount)` on the LINK's contract and as parameters the contract's address (`spender`) and for `amount`: **8000000000000000000**. Then Bob can execute `create` on the contract for issuing the options.
 
@@ -329,7 +322,6 @@ To create the contract, he will give the following parameters:
 - `premium`: **10000000000000000000** *(10 \* 10^(DAI's decimals))*
 - `exerciseWindowStart`: **1689292800** *(2023-07-14 timestamp)*
 - `exerciseWindowEnd`: **1689465600** *(2023-07-16 timestamp)*
-- `data`: **[]**
 
 Bob has to transfer collateral to the contract. This collateral corresponds to the funds he will have to give to Alice if she decides to exercise all the options. He has to give as collateral 200 USDC (8 \* 25) and does that by calling the function `approve(address spender, uint256 amount)` on the USDC's contract. As parameters he will give the contract's address (`spender`) and for `amount`: **200000000** *(`strike`\*`amount` / 10^(LINK's decimals))*. Then he can execute `create` on the contract for issuing the options.
 
@@ -359,7 +351,7 @@ For preventing clear arbitrage cases when option seller considers the issuance t
 
 Once again, we advise writers to frequently check the underlying token price, and take the best decision for them.
 
-**Improvement idea:** if two users agreed for an option off-chain and they want to create it on-chain, there is a risk that between the creation of the contract and the purchase by the second user, an on-chain user has already bought the contract. An implementation of ERC-7390 interface might want to add the allowed addresses e.g. to `data` variable or via a separate function call to define the allowed addresses that can buy options.
+**Improvement idea:** if two users agreed for an option off-chain and they want to create it on-chain, there is a risk that between the creation of the contract and the purchase by the second user, an on-chain user has already bought the contract. An implementation of ERC-7390 interface might want to add the allowed addresses e.g. via a separate function call to define the allowed addresses that can buy options.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ To create the contract, he will give the following parameters:
 - `underlyingToken`: **0x514910771AF9Ca656af840dff83E8264EcF986CA** *(LINK's address)*
 - `amount`: **8000000000000000000** *(8 \* 10^(LINK's decimals))*
 - `strikeToken`: **0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48** *(USDC's address)*
-- `strike`: **200000000** *(8 * 25 \* 10^(USDC's decimals))*
+- `strike`: **25000000** *(25 \* 10^(USDC's decimals))*
 - `premiumToken`: **0x6B175474E89094C44Da98b954EedeAC495271d0F** *(DAI's address)*
 - `premium`: **10000000000000000000** *(10 \* 10^(DAI's decimals))*
 - `exerciseWindowStart`: **1689292800** *(2023-07-14 timestamp)*
@@ -317,7 +317,7 @@ To create the contract, he will give the following parameters:
 - `underlyingToken`: **0x514910771AF9Ca656af840dff83E8264EcF986CA** *(LINK's address)*
 - `amount`: **8000000000000000000** *(8 \* 10^(LINK's decimals))*
 - `strikeToken`: **0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48** *(USDC's address)*
-- `strike`: **200000000** *(8 \* 25 \* 10^(USDC's decimals))*
+- `strike`: **25000000** *(25 \* 10^(USDC's decimals))*
 - `premiumToken`: **0x6B175474E89094C44Da98b954EedeAC495271d0F** *(DAI's address)*
 - `premium`: **10000000000000000000** *(10 \* 10^(DAI's decimals))*
 - `exerciseWindowStart`: **1689292800** *(2023-07-14 timestamp)*

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2022-09-02
-requires: 20
+requires: 1155
 ---
 
 ## Abstract

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Side of the option. Can take the value `Call` or `Put`. `Call` option gives the 
 
 #### `underlyingToken`
 
-**Type: `address` (`IERC20`)**
+**Type: `address` (ERC20 contract)**
 
 Underlying token.
 
@@ -108,7 +108,7 @@ Maximum amount of the underlying tokens that can be exercised.
 
 #### `strikeToken`
 
-**Type: `address` (`IERC20`)**
+**Type: `address` (ERC20 contract)**
 
 Token used as a reference to determine the strike price.
 
@@ -124,7 +124,7 @@ Note that `strike` is set for exercising the total `amount` of options.
 
 #### `premiumToken`
 
-**Type: `address` (`IERC20`)**
+**Type: `address` (ERC20 contract)**
 
 Premium token. 
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Emitted when seller updates the premium to `amount` for option issuance with giv
 
 Let's say Bob sells an **call** option that Alice wants to buy.\
 He gives the right to Alice to buy **8 LINK** tokens at **25 USDC** each between **14th of July 2023** and **16th of July 2023**.\
-For such a contract, he asks Alice to give him **10 DAI** as a premium.\
+For such a contract, he asks Alice to give him **10 DAI** as a premium.
 
 To create the contract, he will give the following parameters:
 
@@ -309,7 +309,7 @@ If she decides to sell the LINK tokens, she just made a profit of 8\*50 - 8\*25 
 
 Let's say Bob sells a put option to Alice.\
 He gives the right to Alice to sell **8 LINK** tokens at **25 USDC** each between **14th of July 2023** and **16th of July 2023**.\
-For such a contract, he asks Alice to give him **10 DAI** as a premium.\
+For such a contract, he asks Alice to give him **10 DAI** as a premium.
 
 To create the contract, he will give the following parameters:
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ---
 eip: 7390
-title: Vanilla Options
-description: An Interface for Vanilla Options
+title: Vanilla Options for ERC-20 Tokens
+description: An interface for creating, managing, and executing simple time-limited call/put (vanilla) options.
 author: Ewan Humbert (@Xeway) <xeway@protonmail.com>, Lassi Maksimainen (@mlalma) <lassi.maksimainen@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/erc-7390-vanilla-option-standard/15206
 status: Draft
 type: Standards Track
 category: ERC
 created: 2022-09-02
-requires: 1155
+requires: 20
 ---
 
 ## Abstract
@@ -142,6 +142,12 @@ Option exercising window start time. When current time is greater or equal to `e
 
 Option exercising window end time. When current time is greater or equal to `exerciseWindowStart` and below or equal to `exerciseWindowEnd`, owner of option(s) can exercise them. When current time is greater than `exerciseWindowEnd`, option holder can't exercise and writer can retrieve remaining underlying (call) or strike (put) tokens.
 
+#### `data`
+
+**Type: `bytes`**
+
+Additional data that can be passed to contract function as a part of option issuance to add flexibility. For standard vanilla options this field is zero-sized array.
+
 ### Function Descriptions
 
 #### `create`
@@ -235,7 +241,7 @@ Returns all the key information for the option issuance with the given `id`.
 event Created(uint256 id);
 ```
 
-Emitted when the writer has provided option issuance data successfully (and locked down the collateral to the contract). The given `id` identifies the particular option issuance.
+Emitted when the writer has provided option issuance data successfully (and locked down the collateral to the contract). The given `id` identifies the particualr option issuance.
 
 #### `Bought`
 
@@ -282,52 +288,52 @@ Emitted when seller updates the premium to `amount` for option issuance with giv
 #### Call Option
 
 Let's say Bob sells an **call** option that Alice wants to buy.\
-He gives the right to Alice to buy **8 LINK** tokens at **25 USDC** each between **14th of July 2023** and **16th of July 2023**.\
-For such a contract, he asks Alice to give him **10 DAI** as a premium.
+He gives the right to Alice to buy **8 TokenA** tokens at **25 TokenB** each between **14th of July 2023** and **16th of July 2023**.\
+For such a contract, he asks Alice to give him **10 TokenC** as a premium.\
 
 To create the contract, he will give the following parameters:
 
 - `side`: **Call**
-- `underlyingToken`: **0x514910771AF9Ca656af840dff83E8264EcF986CA** *(LINK's address)*
-- `amount`: **8000000000000000000** *(8 \* 10^(LINK's decimals))*
-- `strikeToken`: **0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48** *(USDC's address)*
-- `strike`: **25000000** *(25 \* 10^(USDC's decimals))*
-- `premiumToken`: **0x6B175474E89094C44Da98b954EedeAC495271d0F** *(DAI's address)*
-- `premium`: **10000000000000000000** *(10 \* 10^(DAI's decimals))*
+- `underlyingToken`: **TokenA's address**
+- `amount`: **8 \* 10^(TokenA's decimals)**
+- `strikeToken`: **TokenB's address**
+- `strike`: **8 \* 25 \* 10^(TokenB's decimals)**
+- `premiumToken`: **TokenC's address**
+- `premium`: **10 \* 10^(TokenC's decimals)**
 - `exerciseWindowStart`: **1689292800** *(2023-07-14 timestamp)*
 - `exerciseWindowEnd`: **1689465600** *(2023-07-16 timestamp)*
 
-Once the contract created, Bob has to transfer the collateral to the contract. This collateral corresponds to the tokens he will have to give Alice if she decides to exercise the option. For this option, he has to give as collateral 8 LINK. He does that by calling the function `approve(address spender, uint256 amount)` on the LINK's contract and as parameters the contract's address (`spender`) and for `amount`: **8000000000000000000**. Then Bob can execute `create` on the contract for issuing the options.
+Once the contract created, Bob has to transfer the collateral to the contract. This collateral corresponds to the tokens he will have to give Alice if she decides to exercise the option. For this option, he has to give as collateral 8 TokenA. He does that by calling the function `approve(address spender, uint256 amount)` on the TokenA's contract and as parameters the contract's address (`spender`) and for `amount`: **8 \* 10^(TokenA's decimals)**. Then Bob can execute `create` on the contract for issuing the options.
 
-Alice for its part, has to allow the spending of his 10 DAI by calling `approve(address spender, uint256 amount)` on the DAI's contract and give as parameters the contract's address (`spender`) and for `amount`: **10000000000000000000**. She can then execute `buy` on the contract in order to buy the option.
+Alice for its part, has to allow the spending of his 10 TokenC by calling `approve(address spender, uint256 amount)` on the TokenC's contract and give as parameters the contract's address (`spender`) and for `amount`: **10 \* 10^(TokenC's decimals)**. She can then execute `buy` on the contract in order to buy the option.
 
-We're on the 15th of July and Alice wants to exercise her options because 1 LINK is traded at 50 USDC! She needs to allow the contract to transfer **8 * 25000000** USDCs from her account to match the required strike funding. When she calls `exercise` on the contract, the contract will transfer the strike funding to Bob and the LINK tokens that Bob gave as collateral during `create` call to Alice.
+We're on the 15th of July and Alice wants to exercise her options because 1 TokenA is traded at 50 TokenB! She needs to allow the contract to transfer **8 \* 25 \* 10^(TokenB's decimals)** TokenBs from her account to match the required strike funding. When she calls `exercise` on the contract, the contract will transfer the strike funding to Bob and the TokenA tokens that Bob gave as collateral during `create` call to Alice.
 
-If she decides to sell the LINK tokens, she just made a profit of 8\*50 - 8\*25 = 200 USDC!
+If she decides to sell the TokenA tokens, she'd make a profit of 8\*50 - 8\*25 = 200 TokenB!
 
 #### Put Option
 
 Let's say Bob sells a put option to Alice.\
-He gives the right to Alice to sell **8 LINK** tokens at **25 USDC** each between **14th of July 2023** and **16th of July 2023**.\
-For such a contract, he asks Alice to give him **10 DAI** as a premium.
+He gives the right to Alice to sell **8 TokenA** tokens at **25 TokenB** each between **14th of July 2023** and **16th of July 2023**.\
+For such a contract, he asks Alice to give him **10 TokenC** as a premium.\
 
 To create the contract, he will give the following parameters:
 
 - `side`: **Put**
-- `underlyingToken`: **0x514910771AF9Ca656af840dff83E8264EcF986CA** *(LINK's address)*
-- `amount`: **8000000000000000000** *(8 \* 10^(LINK's decimals))*
-- `strikeToken`: **0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48** *(USDC's address)*
-- `strike`: **25000000** *(25 \* 10^(USDC's decimals))*
-- `premiumToken`: **0x6B175474E89094C44Da98b954EedeAC495271d0F** *(DAI's address)*
-- `premium`: **10000000000000000000** *(10 \* 10^(DAI's decimals))*
+- `underlyingToken`: **TokenA's address**
+- `amount`: **8 \* 10^(TokenA's decimals)**
+- `strikeToken`: **TokenB's address**
+- `strike`: **8 \* 25 \* 10^(TokenB's decimals)**
+- `premiumToken`: **TokenC's address**
+- `premium`: **10 \* 10^(TokenC's decimals)**
 - `exerciseWindowStart`: **1689292800** *(2023-07-14 timestamp)*
 - `exerciseWindowEnd`: **1689465600** *(2023-07-16 timestamp)*
 
-Bob has to transfer collateral to the contract. This collateral corresponds to the funds he will have to give to Alice if she decides to exercise all the options. He has to give as collateral 200 USDC (8 \* 25) and does that by calling the function `approve(address spender, uint256 amount)` on the USDC's contract. As parameters he will give the contract's address (`spender`) and for `amount`: **200000000** *(`strike`\*`amount` / 10^(LINK's decimals))*. Then he can execute `create` on the contract for issuing the options.
+Bob has to transfer collateral to the contract. This collateral corresponds to the funds he will have to give to Alice if she decides to exercise all the options. He has to give as collateral 200 TokenB (8 \* 25) and does that by calling the function `approve(address spender, uint256 amount)` on the TokenB's contract. As parameters he will give the contract's address (`spender`) and for `amount`: **(`strike`\*`amount` / 10^(TokenA's decimals))**. Then he can execute `create` on the contract for issuing the options.
 
-Alice for her part has to allow the spending of **10 DAI** by calling `approve(address spender, uint256 amount)` on the DAI's contract, with as parameters the contract's address (`spender`) and for `amount`: **10000000000000000000**. Then, she can execute `buy` on the contract in order to buy all the options.
+Alice for her part has to allow the spending of **10 TokenC** by calling `approve(address spender, uint256 amount)` on the TokenC's contract, with as parameters the contract's address (`spender`) and for `amount`: **10 \* 10^(TokenC's decimals)**. Then, she can execute `buy` on the contract in order to buy all the options.
 
-We're on the 15th of July, and Alice wants to exercise her options because 1 LINK is traded at only 10 USDC! To exercise she has to approve the transferring of **8 LINK** tokens and call `exercise` on the contract. Bob receives 8 LINK tokens, and Alice 200 USDC (8 LINK \* 25 USDC). She just made a profit of 200 - 8\*10 = 120 USDC!
+We're on the 15th of July, and Alice wants to exercise her options because 1 TokenA is traded at only 10 TokenB! To exercise she has to approve the transferring of **8 TokenA** tokens and call `exercise` on the contract. Bob receives 8 TokenA tokens, and Alice 200 TokenB (8 TokenA \* 25 TokenB). She just made a profit of 200 - 8\*10 = 120 TokenB!
 
 #### Retrieve collateral
 
@@ -335,7 +341,6 @@ Let's say Alice never exercised his option because it wasn't profitable enough f
 
 ## Rationale
 
-The proposed ERC option standard provides a simple yet powerful interface for options contracts on Ethereum. By standardizing the interface, it becomes easier for developers to build applications and platforms that support options trading, and users can seamlessly interact with different options contracts across multiple dApps.
 
 This contract's concept is oracle-free, because we assume that a rational buyer will exercise his option only if it's profitable for him.
 
@@ -351,8 +356,8 @@ For preventing clear arbitrage cases when option seller considers the issuance t
 
 Once again, we advise writers to frequently check the underlying token price, and take the best decision for them.
 
-**Improvement idea:** if two users agreed for an option off-chain and they want to create it on-chain, there is a risk that between the creation of the contract and the purchase by the second user, an on-chain user has already bought the contract. An implementation of ERC-7390 interface might want to add the allowed addresses e.g. via a separate function call to define the allowed addresses that can buy options.
+**Improvement idea:** if two users agreed for an option off-chain and they want to create it on-chain, there is a risk that between the creation of the contract and the purchase by the second user, an on-chain user has already bought the contract. An implementation of this proposal's interface might want to add the allowed addresses e.g. to `data` variable or via a separate function call to define the allowed addresses that can buy options.
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://eips.ethereum.org/LICENSE).
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/contracts/ERC7390.sol
+++ b/contracts/ERC7390.sol
@@ -23,7 +23,7 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
         newIssuance.seller = _msgSender();
 
         IERC20 underlyingToken = IERC20(optionData.underlyingToken);
-        newIssuance.totalStrikeTokenCount = (optionData.strike * optionData.amount) / 10 ** underlyingToken.decimals();
+        newIssuance.strikeAmount = (optionData.strike * optionData.amount) / (10 ** underlyingToken.decimals());
         if (optionData.side == Side.Call) {
             _transferFrom(underlyingToken, _msgSender(), address(this), optionData.amount);
         } else {
@@ -31,7 +31,7 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
                 IERC20(optionData.strikeToken),
                 _msgSender(),
                 address(this),
-                newIssuance.totalStrikeTokenCount
+                newIssuance.strikeAmount
             );
         }
 
@@ -54,7 +54,7 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
         if (selectedIssuance.data.premium > 0) {
             uint256 remainder = (amount * selectedIssuance.data.premium) % selectedIssuance.data.amount;
             uint256 premiumPaid = (amount * selectedIssuance.data.premium) / selectedIssuance.data.amount;
-            if (remainder > 0) {premiumPaid += 1;}
+            if (remainder > 0) premiumPaid++;
 
             bool success = IERC20(selectedIssuance.data.premiumToken).transferFrom(
                 _msgSender(),
@@ -84,39 +84,39 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
         IERC20 strikeToken = IERC20(selectedIssuance.data.strikeToken);
 
         uint256 remainder = (amount * selectedIssuance.data.strike) % selectedIssuance.data.amount;
-        uint256 transferredStrikeTokens = (amount * selectedIssuance.data.strike) / selectedIssuance.data.amount;
+        uint256 transferredStrikeAmount = (amount * selectedIssuance.data.strike) / selectedIssuance.data.amount;
 
         if (remainder > 0) {
             if (selectedIssuance.data.side == Side.Call) {
-                transferredStrikeTokens += 1;
+                transferredStrikeAmount++;
             } else {
-                if (transferredStrikeTokens > 0) {
-                    transferredStrikeTokens--;
+                if (transferredStrikeAmount > 0) {
+                    transferredStrikeAmount--;
                 }
             }
         }
 
-        require(transferredStrikeTokens > 0, "transferredStrikeTokens");
+        require(transferredStrikeAmount > 0, "transferredStrikeAmount");
         if (selectedIssuance.data.side == Side.Call) {
             // Buyer pays seller for the underlying token(s) at strike price
-            _transferFrom(strikeToken, _msgSender(), selectedIssuance.seller, transferredStrikeTokens);
+            _transferFrom(strikeToken, _msgSender(), selectedIssuance.seller, transferredStrikeAmount);
 
             // Transfer underlying token(s) to buyer
             _transfer(underlyingToken, _msgSender(), amount);
         } else {
-            require(selectedIssuance.transferredStrikeTokens + transferredStrikeTokens <= selectedIssuance.totalStrikeTokenCount);
-            
+            require(selectedIssuance.transferredStrikeAmount + transferredStrikeAmount <= selectedIssuance.strikeAmount, "Exercise amount exceeds strike amount");
+
             // Buyer transfers the underlying token(s) to writer
             _transferFrom(underlyingToken, _msgSender(), selectedIssuance.seller, amount);
 
             // Pay buyer the strike price
-            _transfer(strikeToken, _msgSender(), transferredStrikeTokens);
+            _transfer(strikeToken, _msgSender(), transferredStrikeAmount);
         }
 
         // Burn used option tokens
         _burn(_msgSender(), id, amount);
         _issuance[id].exercisedOptions += amount;
-        _issuance[id].transferredStrikeTokens += transferredStrikeTokens;
+        _issuance[id].transferredStrikeAmount += transferredStrikeAmount;
 
         emit Exercised(id, amount);
     }
@@ -132,7 +132,7 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
                 uint256 underlyingTokenGiveback = selectedIssuance.data.amount - selectedIssuance.exercisedOptions;
                 _transfer(IERC20(selectedIssuance.data.underlyingToken), _msgSender(), underlyingTokenGiveback);
             } else {
-                uint256 strikeTokenGiveback = selectedIssuance.totalStrikeTokenCount - selectedIssuance.transferredStrikeTokens;
+                uint256 strikeTokenGiveback = selectedIssuance.strikeAmount - selectedIssuance.transferredStrikeAmount;
                 _transfer(IERC20(selectedIssuance.data.strikeToken), _msgSender(), strikeTokenGiveback);
             }                        
         }
@@ -150,7 +150,7 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
         if (selectedIssuance.data.side == Side.Call) {
             _transfer(IERC20(selectedIssuance.data.underlyingToken), _msgSender(), selectedIssuance.data.amount);
         } else {
-            _transfer(IERC20(selectedIssuance.data.strikeToken), _msgSender(), selectedIssuance.totalStrikeTokenCount);          
+            _transfer(IERC20(selectedIssuance.data.strikeToken), _msgSender(), selectedIssuance.strikeAmount);          
         }
 
         delete _issuance[id];

--- a/contracts/ERC7390.sol
+++ b/contracts/ERC7390.sol
@@ -137,8 +137,17 @@ abstract contract ERC7390 is IERC7390, ERC1155, ReentrancyGuard {
 
         require(_msgSender() == selectedIssuance.seller, "seller");
         require(selectedIssuance.soldOptions == 0, "soldOptions");
-
-        _transfer(IERC20(selectedIssuance.data.underlyingToken), _msgSender(), selectedIssuance.data.amount);
+    
+        if (selectedIssuance.data.side == Side.Call) {
+            _transfer(IERC20(selectedIssuance.data.underlyingToken), _msgSender(), selectedIssuance.data.amount);
+        } else {
+            IERC20 underlyingToken = IERC20(selectedIssuance.data.underlyingToken);
+            _transfer(
+                IERC20(selectedIssuance.data.strikeToken),
+                _msgSender(),
+                (selectedIssuance.data.strike * selectedIssuance.data.amount) / 10 ** underlyingToken.decimals()
+            );          
+        }
 
         delete _issuance[id];
         emit Canceled(id);

--- a/contracts/interfaces/IERC7390.sol
+++ b/contracts/interfaces/IERC7390.sol
@@ -24,6 +24,8 @@ interface IERC7390 {
         address seller;
         uint256 exercisedOptions;
         uint256 soldOptions;
+        uint256 transferredStrikeTokens;
+        uint256 totalStrikeTokenCount;
     }
 
     event Created(uint256 indexed id);

--- a/contracts/interfaces/IERC7390.sol
+++ b/contracts/interfaces/IERC7390.sol
@@ -24,8 +24,8 @@ interface IERC7390 {
         address seller;
         uint256 exercisedOptions;
         uint256 soldOptions;
-        uint256 transferredStrikeTokens;
-        uint256 totalStrikeTokenCount;
+        uint256 transferredStrikeAmount;
+        uint256 strikeAmount;
     }
 
     event Created(uint256 indexed id);

--- a/contracts/mocks/MockERC7390.sol
+++ b/contracts/mocks/MockERC7390.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ERC7390 } from "../ERC7390.sol";
+
+contract MockERC7390 is ERC7390 {
+
+  /* solhint-disable-next-line no-empty-blocks */
+  constructor() ERC7390() {}
+}

--- a/test/Option_Create.js
+++ b/test/Option_Create.js
@@ -15,7 +15,6 @@ describe("Creation", function () {
     await token1.connect(acct1).approve(optionContract.target, OPTION_COUNT);
 
     await expect(optionContract.connect(acct1).create(callOption)).to.emit(optionContract, "Created");
-    expect(await optionContract.issuanceCounter()).to.equal(1);
 
     const option = await optionContract.issuance(0);
     expect(option.seller).to.equal(acct1.address);
@@ -44,7 +43,6 @@ describe("Creation", function () {
     await token2.connect(acct1).approve(optionContract.target, TOTAL_UNDERLYING_PRICE);
 
     await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
-    expect(await optionContract.issuanceCounter()).to.equal(1);
 
     const option = await optionContract.issuance(0);
     expect(option.seller).to.equal(acct1.address);

--- a/test/Option_Exercise.js
+++ b/test/Option_Exercise.js
@@ -216,6 +216,6 @@ describe("Exercising", function () {
     await token1.connect(acct2).approve(optionContract.target, boughtOptions);
     await token2.connect(acct2).approve(optionContract.target, premiumPaid);
     await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
-    await expect(optionContract.connect(acct2).exercise(0, 1)).to.be.rejectedWith("transferredStrikeTokens");
+    await expect(optionContract.connect(acct2).exercise(0, 1)).to.be.rejectedWith("transferredStrikeAmount");
   });
 });

--- a/test/Option_Globals.js
+++ b/test/Option_Globals.js
@@ -13,7 +13,7 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 async function deployInfraFixture() {
   const [owner, acct1, acct2, acct3] = await ethers.getSigners();
 
-  const vanillaOption = await ethers.deployContract("ERC7390");
+  const vanillaOption = await ethers.deployContract("MockERC7390");
   await vanillaOption.waitForDeployment();
 
   const token1 = await ethers.deployContract("MockToken1");

--- a/test/Option_Retrieve.js
+++ b/test/Option_Retrieve.js
@@ -8,12 +8,13 @@ const {
   TOKEN2_START_BALANCE,
   OPTION_COUNT,
   PREMIUM,
+  STRIKE,
   ZERO_ADDRESS,
 } = require("./Option_Globals");
 
 describe("Retrieving expired tokens", function () {
-  it("Should retrieve the non-exercised tokens (all)", async function () {
-    const { callOption, optionContract, token1, acct1, currentTime } = await loadFixture(deployInfraFixture);
+  it("Should retrieve the non-exercised tokens (all) of call option", async function () {
+    const { callOption, optionContract, token1, acct1 } = await loadFixture(deployInfraFixture);
 
     await token1.connect(acct1).approve(optionContract.target, OPTION_COUNT);
 
@@ -34,7 +35,29 @@ describe("Retrieving expired tokens", function () {
     expect(option.seller).to.equal(ZERO_ADDRESS);
   });
 
-  it("Should retrieve the non-exercised tokens", async function () {
+  it("Should retrieve the non-exercised tokens (all) of put option", async function () {
+    const { putOption, optionContract, token2, acct1 } = await loadFixture(deployInfraFixture);
+
+    await token2.connect(acct1).approve(optionContract.target, STRIKE);
+
+    await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
+
+    expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - STRIKE);
+
+    await time.increase(2 * 60 * 60);
+
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0)).to.emit(optionContract, "Expired");
+
+    expect(await token2.balanceOf(optionContract.target)).to.equal(0);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE);
+
+    // Make sure data is deleted
+    const option = await optionContract.issuance(0);
+    expect(option.seller).to.equal(ZERO_ADDRESS);
+  });
+
+  it("Should retrieve the non-exercised tokens of call contract", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
     await token1.connect(acct1).approve(optionContract.target, OPTION_COUNT);
     await expect(optionContract.connect(acct1).create(callOption)).to.emit(optionContract, "Created");
@@ -70,6 +93,53 @@ describe("Retrieving expired tokens", function () {
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(0);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - boughtOptions);
+
+    // Make sure data is deleted
+    const option = await optionContract.issuance(0);
+    expect(option.seller).to.equal(ZERO_ADDRESS);
+  });
+
+  it("Should retrieve the non-exercised tokens of put contract", async function () {
+    const { putOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
+    await token2.connect(acct1).approve(optionContract.target, STRIKE);
+    await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
+
+    expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - STRIKE);
+
+    const boughtOptions = Math.ceil(OPTION_COUNT / 6);
+    const premiumPaidModulo = (boughtOptions * PREMIUM) % OPTION_COUNT;
+    let premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT);
+    if (premiumPaidModulo > 0) {
+      premiumPaid += 1;
+    }
+
+    const totalStrikePriceModulo = (boughtOptions * putOption.strike) % OPTION_COUNT;
+    let totalStrikePrice = Math.floor((boughtOptions * putOption.strike) / OPTION_COUNT);
+
+    if (totalStrikePriceModulo > 0) {
+      totalStrikePrice--;
+    }
+
+    await token1.connect(acct2).approve(optionContract.target, boughtOptions);
+    await token2.connect(acct2).approve(optionContract.target, premiumPaid);
+    await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
+
+    const exercisableOptions = await optionContract.balanceOf(acct2.address, 0);
+    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.emit(optionContract, "Exercised");
+
+    expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE - totalStrikePrice);    
+    expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE + boughtOptions);
+    expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE - boughtOptions);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid - STRIKE);
+    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid + totalStrikePrice);
+    
+    await time.increase(2 * 60 * 60);
+
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0)).to.emit(optionContract, "Expired");
+
+    expect(await token2.balanceOf(optionContract.target)).to.equal(0);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - totalStrikePrice + premiumPaid);
 
     // Make sure data is deleted
     const option = await optionContract.issuance(0);


### PR DESCRIPTION
This pull request contains following fixes:
- Fixes test code as ERC-7390 contract is now abstract
- Fixes issue on cancel() when issuer has issued a put option; tokens were not correctly returned to issuer
- Fixes issue on retrieveExpiredTokens() when issuer has issued a put option; tokens were not correctly returned to issuer