### PR TITLE
Fixed asking too much collateral when creating put options issuance, fixed rounding down the amounts on buy() and exercise(), fixed the unit tests

### DIFF
--- a/test/Option_Buy.js
+++ b/test/Option_Buy.js
@@ -33,9 +33,7 @@ describe("Buying", function () {
 
   it("Should buy put options", async function () {
     const { putOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
-
-    const totalUnderlyingPrice = (OPTION_COUNT * STRIKE) / 10 ** 6;
-    await token2.connect(acct1).approve(optionContract.target, totalUnderlyingPrice);
+    await token2.connect(acct1).approve(optionContract.target, putOption.strike);
     await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
 
     const boughtOptions = OPTION_COUNT / 10;
@@ -47,8 +45,8 @@ describe("Buying", function () {
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE);
 
-    expect(await token2.balanceOf(optionContract.target)).to.equal(totalUnderlyingPrice);
-    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - totalUnderlyingPrice + premiumPaid);
+    expect(await token2.balanceOf(optionContract.target)).to.equal(putOption.strike);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - putOption.strike + premiumPaid);
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid);
 
     expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions);
@@ -59,7 +57,10 @@ describe("Buying", function () {
     const boughtOptions = OPTION_COUNT / 10;
     const premiumPaid = (boughtOptions * PREMIUM) / OPTION_COUNT;
     await token2.connect(acct2).approve(optionContract.target, premiumPaid);
-    await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT / 10)).to.be.revertedWith("exceriseWindowEnd");
+    await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT / 10)).to.be.revertedWithCustomError(
+      optionContract,
+      "AmountForbidden"
+    );
   });
 
   it("Should fail to buy options that are expired", async function () {
@@ -73,7 +74,10 @@ describe("Buying", function () {
 
     await time.increase(2 * 60 * 60);
 
-    await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT / 10)).to.be.rejectedWith("exceriseWindowEnd");
+    await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT / 10)).to.be.revertedWithCustomError(
+      optionContract,
+      "TimeForbidden"
+    );
   });
 
   it("Should fail to buy options because there are no options to be bought", async function () {
@@ -87,7 +91,10 @@ describe("Buying", function () {
     await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT)).to.emit(optionContract, "Bought");
 
     // All options bought, verify we can't buy any more of them
-    await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT)).to.be.revertedWith("amount");
+    await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT)).to.be.revertedWithCustomError(
+      optionContract,
+      "AmountForbidden"
+    );
 
     expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions);
   });
@@ -102,26 +109,27 @@ describe("Buying", function () {
     );
   });
 
-  it("Should adjust due to the zero premium when buying options", async function () {
+  it("Should fail due to the zero premium when buying options", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
     await token1.connect(acct1).approve(optionContract.target, OPTION_COUNT);
     await expect(optionContract.connect(acct1).create(callOption)).to.emit(optionContract, "Created");
 
     const boughtOptions = OPTION_COUNT / 2;
-    const premiumPaid = Math.ceil((boughtOptions * PREMIUM) / OPTION_COUNT);
-    await token2.connect(acct2).approve(optionContract.target, 2 * premiumPaid);
-    // Trying to buy too few option tokens, which would lead to zero premium
-    await expect(optionContract.connect(acct2).buy(0, 10)).to.emit(optionContract, "Bought");
+    // Trying to buy too few option tokens, which would lead to zero premium and fail when trying to buy an option
+    await expect(optionContract.connect(acct2).buy(0, 10)).to.be.revertedWithCustomError(
+      optionContract,
+      "AmountForbidden"
+    );
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE);
 
     expect(await token2.balanceOf(optionContract.target)).to.equal(0);
-    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + 1);
-    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - 1);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE);
+    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE);
 
-    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(10);
+    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(0);
   });
 
   it("Should adjust bought option count when modulo ≠ 0", async function () {
@@ -129,21 +137,22 @@ describe("Buying", function () {
     await token1.connect(acct1).approve(optionContract.target, OPTION_COUNT);
     await expect(optionContract.connect(acct1).create(callOption)).to.emit(optionContract, "Created");
 
-    const boughtOptions = OPTION_COUNT / 2;
-    const premiumPaid = Math.ceil((boughtOptions * PREMIUM) / OPTION_COUNT);
+    let boughtOptions = 17 + OPTION_COUNT / 2;
+    const premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT);
     await token2.connect(acct2).approve(optionContract.target, 2 * premiumPaid);
 
-    // Shouldn't be able to buy extra 17 tokens, instead the option token count should be OPTION_COUNT / 2
-    await expect(optionContract.connect(acct2).buy(0, 17 + OPTION_COUNT / 2)).to.emit(optionContract, "Bought");
+    // Shouldn't be able to buy extra 17 tokens since we would not be paying extra premium for them
+    // Instead the option token count should be OPTION_COUNT / 2
+    await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE);
 
     expect(await token2.balanceOf(optionContract.target)).to.equal(0);
-    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid + 1);
-    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid - 1);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid);
+    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid);
 
-    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(17 + OPTION_COUNT / 2);
+    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(OPTION_COUNT / 2);
   });
 });

--- a/test/Option_Cancel.js
+++ b/test/Option_Cancel.js
@@ -32,7 +32,7 @@ describe("Canceling", function () {
     expect(option.writer).to.equal(ZERO_ADDRESS);
   });
 
-  it("Should cancel the put option contract and return the underlying to writer", async function() {
+  it("Should cancel the put option contract and return the underlying to writer", async function () {
     const { putOption, optionContract, token2, acct1 } = await loadFixture(deployInfraFixture);
 
     await token2.connect(acct1).approve(optionContract.target, STRIKE);
@@ -73,7 +73,10 @@ describe("Canceling", function () {
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid);
     expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions);
 
-    await expect(optionContract.connect(acct1).cancel(0, acct1.address)).to.be.revertedWith("soldAmount");
+    await expect(optionContract.connect(acct1).cancel(0, acct1.address)).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
 
     const option = await optionContract.issuance(0);
     expect(option.writer).to.not.equal(ZERO_ADDRESS);
@@ -81,7 +84,10 @@ describe("Canceling", function () {
 
   it("Should fail to cancel since no issuance exists", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
-    await expect(optionContract.connect(acct1).cancel(0), acct1.address).to.be.revertedWith("writer");
+    await expect(optionContract.connect(acct1).cancel(0, ZERO_ADDRESS), acct1.address).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
   });
 
   it("Should fail to cancel since the canceling party is not the writer", async function () {
@@ -94,6 +100,9 @@ describe("Canceling", function () {
     expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
 
-    await expect(optionContract.connect(acct2).cancel(0, acct2.address)).to.be.revertedWith("writer");
+    await expect(optionContract.connect(acct2).cancel(0, acct2.address)).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
   });
 });

--- a/test/Option_Exercise.js
+++ b/test/Option_Exercise.js
@@ -43,31 +43,22 @@ describe("Exercising", function () {
     await token2.connect(acct1).approve(optionContract.target, totalUnderlyingPrice);
     await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
 
-    const boughtOptions = Math.ceil(OPTION_COUNT / 6);
-    const premiumPaidModulo = (boughtOptions * PREMIUM) % OPTION_COUNT;
+    let boughtOptions = Math.ceil(OPTION_COUNT / 6);
     let premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT);
-    if (premiumPaidModulo > 0) {
-      premiumPaid += 1;
-    }
-
-    const totalStrikePriceModulo = (boughtOptions * putOption.strike) % OPTION_COUNT;
-    let totalStrikePrice = Math.floor((boughtOptions * putOption.strike) / OPTION_COUNT);
-
-    if (totalStrikePriceModulo > 0) {
-      totalStrikePrice--;
-    }
 
     await token1.connect(acct2).approve(optionContract.target, boughtOptions);
     await token2.connect(acct2).approve(optionContract.target, premiumPaid);
     await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
 
-    const exercisableOptions = await optionContract.balanceOf(acct2.address, 0);
-    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.emit(optionContract, "Exercised");
+    boughtOptions = Math.floor((premiumPaid * OPTION_COUNT) / PREMIUM);
+    let totalStrikePrice = Math.floor((boughtOptions * putOption.strike) / OPTION_COUNT);
+
+    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions);
+    await expect(optionContract.connect(acct2).exercise(0, boughtOptions)).to.emit(optionContract, "Exercised");
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(0);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE + boughtOptions);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE - boughtOptions);
-
     expect(await token2.balanceOf(optionContract.target)).to.equal(totalUnderlyingPrice - totalStrikePrice);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid - totalUnderlyingPrice);
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid + totalStrikePrice);
@@ -87,12 +78,18 @@ describe("Exercising", function () {
     await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT / 10)).to.emit(optionContract, "Bought");
 
     const exercisableOptions = await optionContract.balanceOf(acct2.address, 0);
-    await expect(optionContract.connect(acct2).exercise(0, 0)).to.be.rejectedWith("amount");
+    await expect(optionContract.connect(acct2).exercise(0, 0)).to.be.revertedWithCustomError(
+      optionContract,
+      "AmountForbidden"
+    );
   });
 
   it("Should fail to exercise option because there is no issuance", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
-    await expect(optionContract.connect(acct2).exercise(0, OPTION_COUNT)).to.be.rejectedWith("balance");
+    await expect(optionContract.connect(acct2).exercise(0, OPTION_COUNT)).to.be.revertedWithCustomError(
+      optionContract,
+      "InsufficientBalance"
+    );
   });
 
   it("Should fail to exercise option because exercise window is not yet open", async function () {
@@ -112,7 +109,10 @@ describe("Exercising", function () {
     await expect(optionContract.connect(acct2).buy(0, OPTION_COUNT / 10)).to.emit(optionContract, "Bought");
 
     const exercisableOptions = await optionContract.balanceOf(acct2.address, 0);
-    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.revertedWith("timestamp");
+    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.be.revertedWithCustomError(
+      optionContract,
+      "TimeForbidden"
+    );
   });
 
   it("Should fail to exercise option because exercise window is closed", async function () {
@@ -127,31 +127,31 @@ describe("Exercising", function () {
 
     const exercisableOptions = await optionContract.balanceOf(acct2.address, 0);
     await time.increase(2 * 60 * 60);
-    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.revertedWith("timestamp");
+    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.be.revertedWithCustomError(
+      optionContract,
+      "TimeForbidden"
+    );
   });
 
-  it("Should adjust pricing for call because of the rounding of transferred tokens", async function () {
+  it("Exercising exactly one token and then the rest from call contract", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
     await token1.connect(acct1).approve(optionContract.target, OPTION_COUNT);
     await expect(optionContract.connect(acct1).create(callOption)).to.emit(optionContract, "Created");
 
     const boughtOptions = OPTION_COUNT / 10;
-    const premiumPaidModulo = (boughtOptions * PREMIUM) % OPTION_COUNT;
-    const premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT) + (premiumPaidModulo > 0 ? 1 : 0);
-    const totalStrikeModulo = (1 * callOption.strike) % OPTION_COUNT;
-    const totalStrikePrice = Math.floor((1 * callOption.strike) / OPTION_COUNT) + (totalStrikeModulo > 0 ? 1 : 0);
-    await token2.connect(acct2).approve(optionContract.target, premiumPaid + totalStrikePrice);
+    const premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT);
+    // Buy exactly one token, i.e. absolutely nothing
+    let totalStrikePrice = Math.floor(callOption.strike / OPTION_COUNT);
 
+    await token2.connect(acct2).approve(optionContract.target, premiumPaid + totalStrikePrice);
     await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE);
-
     expect(await optionContract.balanceOf(optionContract.target, 0)).to.equal(0);
     expect(await optionContract.balanceOf(acct1.address, 0)).to.equal(0);
     expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions);
-
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid);
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid);
 
@@ -160,28 +160,36 @@ describe("Exercising", function () {
     expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT - 1);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE + 1);
-
     expect(await token2.balanceOf(optionContract.target)).to.equal(0);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid + totalStrikePrice);
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid - totalStrikePrice);
-
     expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions - 1);
+
+    // Exercise the rest
+    totalStrikePrice = Math.floor((boughtOptions * callOption.strike) / OPTION_COUNT);
+    await token2.connect(acct2).approve(optionContract.target, totalStrikePrice);
+    await expect(optionContract.connect(acct2).exercise(0, boughtOptions - 1)).to.emit(optionContract, "Exercised");
+
+    expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT - boughtOptions);
+    expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
+    expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE + boughtOptions);
+    expect(await token2.balanceOf(optionContract.target)).to.equal(0);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid + totalStrikePrice);
+    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid - totalStrikePrice);
+    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(0);
   });
 
-  it("Should adjust pricing for put because of the rounding of transferred tokens", async function () {
+  it("Exercising small amount of options tied to put contract", async function () {
     const { putOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
 
-    const totalUnderlyingPrice = (OPTION_COUNT * STRIKE) / 10 ** 6;
+    const totalUnderlyingPrice = STRIKE;
     await token2.connect(acct1).approve(optionContract.target, totalUnderlyingPrice);
     await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
 
     const boughtOptions = OPTION_COUNT / 10;
-    const premiumPaidModulo = (boughtOptions * PREMIUM) % OPTION_COUNT;
-    const premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT) + (premiumPaidModulo > 0 ? 1 : 0);
+    const premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT);
     const exercisedAmount = 5;
-    const totalStrikePriceModulo = (exercisedAmount * putOption.strike) % OPTION_COUNT;
-    const totalStrikePrice =
-      Math.floor((exercisedAmount * putOption.strike) / OPTION_COUNT) + (totalStrikePriceModulo > 0 ? 1 : 0);
+
     await token1.connect(acct2).approve(optionContract.target, boughtOptions);
     await token2.connect(acct2).approve(optionContract.target, premiumPaid);
     await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
@@ -191,6 +199,7 @@ describe("Exercising", function () {
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE + exercisedAmount);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE - exercisedAmount);
 
+    let totalStrikePrice = Math.floor((exercisedAmount * STRIKE) / OPTION_COUNT);
     expect(await token2.balanceOf(optionContract.target)).to.equal(totalUnderlyingPrice - totalStrikePrice);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid - totalUnderlyingPrice);
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid + totalStrikePrice);
@@ -216,6 +225,9 @@ describe("Exercising", function () {
     await token1.connect(acct2).approve(optionContract.target, boughtOptions);
     await token2.connect(acct2).approve(optionContract.target, premiumPaid);
     await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
-    await expect(optionContract.connect(acct2).exercise(0, 1)).to.be.rejectedWith("transferredExerciseCost");
+    await expect(optionContract.connect(acct2).exercise(0, 1)).to.be.revertedWithCustomError(
+      optionContract,
+      "AmountForbidden"
+    );
   });
 });

--- a/test/Option_Globals.js
+++ b/test/Option_Globals.js
@@ -31,7 +31,7 @@ async function deployInfraFixture() {
   await token2.connect(acct3).faucet(TOKEN2_START_BALANCE);
 
   const emptyBytes = ethers.AbiCoder.defaultAbiCoder().encode(["string"], [""]);
-  
+
   currentTime = await time.latest();
 
   const callOption = {
@@ -44,7 +44,7 @@ async function deployInfraFixture() {
     premium: PREMIUM,
     exerciseWindowStart: currentTime,
     exerciseWindowEnd: currentTime + 60 * 60,
-    data: emptyBytes
+    allowed: [],
   };
 
   const putOption = {
@@ -57,7 +57,7 @@ async function deployInfraFixture() {
     premium: PREMIUM,
     exerciseWindowStart: currentTime,
     exerciseWindowEnd: currentTime + 60 * 60,
-    data: emptyBytes
+    allowed: [],
   };
 
   return {

--- a/test/Option_Retrieve.js
+++ b/test/Option_Retrieve.js
@@ -25,7 +25,10 @@ describe("Retrieving expired tokens", function () {
 
     await time.increase(2 * 60 * 60);
 
-    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(optionContract, "Expired");
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(
+      optionContract,
+      "Expired"
+    );
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(0);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE);
@@ -47,7 +50,10 @@ describe("Retrieving expired tokens", function () {
 
     await time.increase(2 * 60 * 60);
 
-    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(optionContract, "Expired");
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(
+      optionContract,
+      "Expired"
+    );
 
     expect(await token2.balanceOf(optionContract.target)).to.equal(0);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE);
@@ -89,7 +95,10 @@ describe("Retrieving expired tokens", function () {
 
     await time.increase(2 * 60 * 60);
 
-    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(optionContract, "Expired");
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(
+      optionContract,
+      "Expired"
+    );
 
     expect(await token1.balanceOf(optionContract.target)).to.equal(0);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - boughtOptions);
@@ -103,40 +112,37 @@ describe("Retrieving expired tokens", function () {
     const { putOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
     await token2.connect(acct1).approve(optionContract.target, STRIKE);
     await expect(optionContract.connect(acct1).create(putOption)).to.emit(optionContract, "Created");
-
     expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - STRIKE);
 
-    const boughtOptions = Math.ceil(OPTION_COUNT / 6);
-    const premiumPaidModulo = (boughtOptions * PREMIUM) % OPTION_COUNT;
+    let boughtOptions = Math.ceil(OPTION_COUNT / 6);
     let premiumPaid = Math.floor((boughtOptions * PREMIUM) / OPTION_COUNT);
-    if (premiumPaidModulo > 0) {
-      premiumPaid += 1;
-    }
 
-    const totalStrikePriceModulo = (boughtOptions * putOption.strike) % OPTION_COUNT;
-    let totalStrikePrice = Math.floor((boughtOptions * putOption.strike) / OPTION_COUNT);
-
-    if (totalStrikePriceModulo > 0) {
-      totalStrikePrice--;
-    }
-
-    await token1.connect(acct2).approve(optionContract.target, boughtOptions);
     await token2.connect(acct2).approve(optionContract.target, premiumPaid);
     await expect(optionContract.connect(acct2).buy(0, boughtOptions)).to.emit(optionContract, "Bought");
 
-    const exercisableOptions = await optionContract.balanceOf(acct2.address, 0);
-    await expect(optionContract.connect(acct2).exercise(0, exercisableOptions)).to.emit(optionContract, "Exercised");
+    expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE);
+    expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid - STRIKE);
+    expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid);
+    boughtOptions = Math.floor((premiumPaid * OPTION_COUNT) / PREMIUM);
+    expect(await optionContract.balanceOf(acct2.address, 0)).to.equal(boughtOptions);
 
-    expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE - totalStrikePrice);    
+    await token1.connect(acct2).approve(optionContract.target, boughtOptions);
+    await expect(optionContract.connect(acct2).exercise(0, boughtOptions)).to.emit(optionContract, "Exercised");
+
+    const totalStrikePrice = Math.floor((boughtOptions * STRIKE) / OPTION_COUNT);
+    expect(await token2.balanceOf(optionContract.target)).to.equal(STRIKE - totalStrikePrice);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE + boughtOptions);
     expect(await token1.balanceOf(acct2.address)).to.equal(TOKEN1_START_BALANCE - boughtOptions);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE + premiumPaid - STRIKE);
     expect(await token2.balanceOf(acct2.address)).to.equal(TOKEN2_START_BALANCE - premiumPaid + totalStrikePrice);
-    
+
     await time.increase(2 * 60 * 60);
 
-    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(optionContract, "Expired");
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.emit(
+      optionContract,
+      "Expired"
+    );
 
     expect(await token2.balanceOf(optionContract.target)).to.equal(0);
     expect(await token2.balanceOf(acct1.address)).to.equal(TOKEN2_START_BALANCE - totalStrikePrice + premiumPaid);
@@ -148,7 +154,10 @@ describe("Retrieving expired tokens", function () {
 
   it("Should fail to retrieve tokens since no issuance exists", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
-    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.be.revertedWith("writer");
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
   });
 
   it("Should fail to retrieve tokens since retriever is not the writer", async function () {
@@ -163,7 +172,10 @@ describe("Retrieving expired tokens", function () {
 
     await time.increase(2 * 60 * 60);
 
-    await expect(optionContract.connect(acct2).retrieveExpiredTokens(0, acct2.address)).to.be.revertedWith("writer");
+    await expect(optionContract.connect(acct2).retrieveExpiredTokens(0, acct2.address)).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
   });
 
   it("Should fail to retrieve tokens since exercise window is still open", async function () {
@@ -176,6 +188,9 @@ describe("Retrieving expired tokens", function () {
     expect(await token1.balanceOf(optionContract.target)).to.equal(OPTION_COUNT);
     expect(await token1.balanceOf(acct1.address)).to.equal(TOKEN1_START_BALANCE - OPTION_COUNT);
 
-    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.be.revertedWith("exerciseWindowEnd");
+    await expect(optionContract.connect(acct1).retrieveExpiredTokens(0, acct1.address)).to.be.revertedWithCustomError(
+      optionContract,
+      "TimeForbidden"
+    );
   });
 });

--- a/test/Option_UpdatePremium.js
+++ b/test/Option_UpdatePremium.js
@@ -1,12 +1,7 @@
 const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
-const {
-  deployInfraFixture,
-  TOKEN2_START_BALANCE,
-  OPTION_COUNT,
-  PREMIUM,
-} = require("./Option_Globals");
+const { deployInfraFixture, TOKEN2_START_BALANCE, OPTION_COUNT, PREMIUM } = require("./Option_Globals");
 
 describe("Updating option premium", function () {
   it("Should update premium successfully", async function () {
@@ -34,7 +29,10 @@ describe("Updating option premium", function () {
 
   it("Should fail to update since no issuance exists", async function () {
     const { callOption, optionContract, token1, token2, acct1, acct2 } = await loadFixture(deployInfraFixture);
-    await expect(optionContract.connect(acct1).updatePremium(0, 1)).to.be.revertedWith("writer");
+    await expect(optionContract.connect(acct1).updatePremium(0, 1)).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
   });
 
   it("Should fail to update premium since the updater is not the writer", async function () {
@@ -44,6 +42,9 @@ describe("Updating option premium", function () {
 
     await expect(optionContract.connect(acct1).create(callOption)).to.emit(optionContract, "Created");
 
-    await expect(optionContract.connect(acct2).updatePremium(0, 1)).to.be.revertedWith("writer");
+    await expect(optionContract.connect(acct2).updatePremium(0, 1)).to.be.revertedWithCustomError(
+      optionContract,
+      "Forbidden"
+    );
   });
 });


### PR DESCRIPTION
- FIX: On create() the options issuer was asked to post too much collateral when creating put options issuance
- FIX: Rounding down the amounts on buy() and exercise() for preventing problems and potential attacks when trying to buy or exercise for option counts with fraction counts
- Updated unit tests to follow the changes in API and how error cases are handled